### PR TITLE
Adds team directories and READMEs with some basic starter info

### DIFF
--- a/teams/README.md
+++ b/teams/README.md
@@ -1,0 +1,96 @@
+# GETTING STARTED
+
+[Drupal Documentation](https://www.drupal.org/documentation )
+
+The examples in this documentation uses path "/var/www/html/drupal8.dev" and
+virtual host "drupal8.dev", you should substitute as necessary.
+
+## COMPOSER
+
+
+### Install composer and create a new Drupal site
+
+[Using Composer To Manage Drupal Dependencies](https://www.drupal.org/docs/develop/using-composer/using-composer-to-manage-drupal-site-dependencies )
+
+For a quick and easy start that will install Drupal Console, Drush and PHPUnit
+try [Option A: drupal-composer/drupal-project](https://github.com/drupal-composer/drupal-project )
+
+### Update Drupal core
+
+```
+/var/www/html/drupal8.dev $ composer update drupal/core --with-dependencies
+```
+
+### Import a Drupal module
+
+```
+/var/www/html/drupal8.dev $ composer require drupal/<module_name\>
+```
+
+### Update a Drupal module
+
+```
+/var/www/html/drupal8.dev $ composer update drupal/<module_name\>
+```
+
+## DRUPAL CONSOLE
+
+If you created your Drupal site using composer, Drupal Console and Drush
+will already be installed. If not, you can install Console using Composer.
+
+[Install Drupal Console Using Composer](https://docs.drupalconsole.com/en/getting/composer.html)
+
+[Online Documentation](https://hechoendrupal.gitbooks.io/drupal-console/content/en/index.html)
+
+### Setup developer mode
+
+```
+/var/www/html/drupal8.dev $ cp web/sites/default/default.services.yml web/sites/default/services.yml
+/var/www/html/drupal8.dev $ cp web/sites/example.settings.local.php web/sites/settings.local.php
+/var/www/html/drupal8.dev $ drupal site:mode dev
+```
+
+Uncomment the code following this comment in web/sites/default/settings.php
+```
+* Load local development override configuration, if available.
+```
+
+## DRUSH
+
+[Documentation](http://docs.drush.org/en/8.x/ )
+
+## CODING STANDARDS
+
+[Drupal Coding Standards](https://www.drupal.org/docs/develop/standards)
+
+[Drupal Coder Project](https://www.drupal.org/project/coder)
+
+### Install/Configure Coder
+
+[Installing Coder Sniffer](https://www.drupal.org/node/1419988)
+
+```
+/var/www/html/drupal8.dev $ composer global require drupal/coder
+/var/www/html/drupal8.dev $ composer global require dealerdirect/phpcodesniffer-composer-installer
+/var/www/html/drupal8.dev $ sudo ln -s /home/admin/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs /usr/bin/phpcs
+/var/www/html/drupal8.dev $ file /usr/bin/phpcs
+/var/www/html/drupal8.dev $ sudo ln -s /home/admin/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcbf /usr/bin/phpcbf
+/var/www/html/drupal8.dev $ file /usr/bin/phpcbf
+/var/www/html/drupal8.dev $ phpcs --config-set installed_paths /home/admin/.composer/vendor/drupal/coder/coder_sniffer
+```
+
+### Usage - check code
+
+```
+/var/www/html/drupal8.dev/web/modules $ phpcs --standard=Drupal mymodule > mymodule.diff
+```
+
+### Usage - fix code
+
+`/var/www/html/drupal8.devweb/modules $ phpcbf --standard=Drupal mymodule > mymodule.fix`
+
+_Note_: Use caution with phpcbf, commit code first to ensure you can rollback if necessary.
+
+[Drupal Markdown Coding Standards](https://www.drupal.org/docs/develop/coding-standards/markdown-coding-standards) are yet to be confirmed
+
+

--- a/teams/backend/README.md
+++ b/teams/backend/README.md
@@ -1,0 +1,11 @@
+# BACKEND TEAM
+
+## USEFUL LINKS
+
+[Drupal Documentation](https://www.drupal.org/documentation)
+
+[Drupal 8 API](https://www.drupal.org/docs/8/api)
+
+[Drupal 8 Security](https://www.drupal.org/docs/8/security)
+
+[Debugging with XDebug](https://www.drupal.org/docs/develop/development-tools/xdebug-debugger)

--- a/teams/backend/testing/README.md
+++ b/teams/backend/testing/README.md
@@ -1,0 +1,52 @@
+# DRUPAL TESTS
+
+[Drupal 8 Testing](https://www.drupal.org/docs/8/testing )
+
+[Drupal 8 PHPUnit](https://www.drupal.org/docs/8/phpunit )
+
+[Running PHPUnit Tests](https://www.drupal.org/docs/8/phpunit/running-phpunit-tests )
+
+[PHPUnit](https://phpunit.de/ )
+
+[Simpletest Countdown](http://simpletest-countdown.org/ )
+
+[Convert all Simpletest web tests to BrowserTestBase (or UnitTestBase/KernelTestBase)](https://www.drupal.org/node/2735005 )
+
+## PHPUNIT
+
+If you created your Drupal site using composer, PHPUnit should already be installed.
+
+Run PHPUnit tests from the <docroot>/core folder.
+
+```
+cd /var/www/html/drupal8.dev/web/core
+../../vendor/bin/phpunit -v -c ../modules/mymodule/tests/src/Functional/MyTest.php
+```
+
+## DRUPAL TEST RUNNER
+
+Configure the Drupal PHPUnit environment.
+
+```
+cp /var/www/html/drupal8.dev/web/core/phpunit.xml.dist /var/www/html/drupal8.dev/web/core/phpunit.xml
+```
+
+Edit phpunit.xml to fill in SIMPLETEST_DB, SIMPLETEST_BASE_URL,
+BROWSERTEST_OUTPUT_DIRECTORY and uncomment the printerClass property in the
+phpunit tag. See [Running PHPUnit Tests](https://www.drupal.org/docs/8/phpunit/running-phpunit-tests ) for more details.
+
+```
+/var/www/html/drupal8.dev/web $ drupal module:install simpletest
+/var/www/html/drupal8.dev/web $ chown -R www-data:www-data sites/default/files
+```
+
+Note that if you are using a vhost URL you need to specify the --url arg as it
+is not picked up from the phpunit.xml config file and defaults to http://localhost.
+
+```
+/var/www/html/drupal8.dev/web $ php core/scripts/run-tests.sh --url http://drupal8.dev --module mymodule
+/var/www/html/drupal8.dev/web $ php core/scripts/run-tests.sh --url http://drupal8.dev --directory modules/mymodule
+/var/www/html/drupal8.dev/web $ php core/scripts/run-tests.sh --url http://drupal8.dev --class "Drupal\Tests\mymodule\Unit\MyTest"
+/var/www/html/drupal8.dev/web $ php core/scripts/run-tests.sh --url http://drupal8.dev --class "Drupal\Tests\mymodule\Functional\MyTest"
+/var/www/html/drupal8.dev/web $ php core/scripts/run-tests.sh --verbose --clean
+```

--- a/teams/frontend/README.md
+++ b/teams/frontend/README.md
@@ -1,0 +1,11 @@
+# FRONTEND TEAM
+
+## USEFUL LINKS
+
+[Drupal Documentation](https://www.drupal.org/documentation)
+
+[Drupal 8 Theming](https://www.drupal.org/docs/8/theming/twig/debugging-twig-templates)
+
+[Drupal 8 Twig XDebug Project](https://www.drupal.org/project/twig_xdebug)
+
+[Functions In Twig Templates](https://www.drupal.org/docs/8/theming/twig/functions-in-twig-templates)


### PR DESCRIPTION
First commit. Suggests a few organisational elements along with some "getting started" info in markdown format. Also, good practice to use PRs right from the start. Plus allows others to suggest changes to this PR and point out any typos or stupid that I may have let in.

The README content can be moved to the wiki if desired although for developers it might be useful to keep some "cheat sheet" info close to the code, snippets, examples, data or whatever else we'll be putting in the repo.
