### PR TITLE
Meeting notes

### DIFF
--- a/meeting-notes/general/2017.10.05.md
+++ b/meeting-notes/general/2017.10.05.md
@@ -1,0 +1,115 @@
+# Contrib Team Meeting #1
+Meeting date/time: 2017.10.05, 10 am PDT
+Meeting led by: sparklingrobots and mdrummond
+
+## NEXT STEPS: 
+* Everyone: Fill out the survey: https://goo.gl/forms/cOFOttWG08x4qwm63
+* [FRONT END] Tori will work on kick-off docs in Google Drive (team roster, first meeting agenda ideas, theming brainstorming and questions to address). If you feel like jumping on the ball, please DM for access. 
+* [FRONT END] Set up regular meeting times. (Tori/kefletcher)
+* [BACK END] Set up regular meeting times. (sparklingrobots)
+* [BACK END] Find another leader, preferably a PM.
+* Investigate groups on d.o (sparklingrobots)
+* Investigate Rocketship. (who?)
+* Set up DDI github for managing the work to get our “official tools” up and running (sparklingrobots)
+* Tori will research best practices, and using D.O for project management.
+* [MENTORING] Determine monthly meeting time. (sparklingrobots)
+* Determine who will lead group onboarding and what we will cover. (@angelam is on it: https://github.com/drupaldiversity/contrib/issues/2)
+* Find a place for the survey info to live where everyone can access/update it.
+* Add “modeling better metrics” as a goal of the group. (But where?)
+* Build next, better survey. 
+* Distinguish between “issues-based discussions” that should live on d.o and “process discussions” that can live outside of d.o
+
+## INTROS
+Listed in alphabetical order by slack username:
+* alannaburke
+* angelam
+* cboyden
+* laurarocks
+* mdrummond 
+* sacarney 
+* sparklingrobots 
+* sugaroverflow
+* tim.plunkett
+* Tori  
+
+## Meeting Overview
+* The goal of our project: To increase code-based contributions from individuals from under-represented groups to the Drupal project.
+* This channel right now is being used to organize a mentoring program. During this meeting the goal is to formalize the first group/cohort of mentors/mentees and develop a plan to support them as they work together.
+
+## Survey
+* Tara threw together a google form and requested everyone fill it out: https://goo.gl/forms/cOFOttWG08x4qwm63
+
+## Forming Front-End Team
+* End of cohort is end of 2017. 
+* Project Leads: Tori & kefletcher
+* Volunteers: 
+	* mdrummond (mentor)
+	* sacarney (HTML/CSS/Twig and can help with design and a11y
+	* Tori (HTML/CSS and can help with project management and documentation)
+	* kefletcher
+	* cboyden (mentor for accessibility and how-to-contribute, mentee/learner on JS and Twig for D8.)
+	* laurarocks (html/css/twig stuff I can help with, maybe designs too.)
+* Known needs: 
+	* Guidance on using standard community tools & practices (e.g. drupal.org) 
+	* What kind of theme we are making here, what issue is it supposed to address? who is it for? what specific problem can we solve with it? whats going to make it different from every other contrib theme?
+
+## Forming Back-End Team
+* End of cohort is end of 2017.
+* Leader: sparklingrobots
+* Volunteers:
+	* alannaburke
+	* sparklingrobots 
+	* mdrummond  (interested in making contributions on this one. The Media Entity API updates for contrib and updating core tests both sound like interesting challenges. Glad to help others with the whole process for contributing too.)
+	* angelam
+	* sugaroverflow (back-end-y and would like to be helpful)
+	* laurarocks
+	* cboyden
+	* agentrickard (help people with back-end things and some test basics)
+	* zenlan
+* We voted on three options: 
+	* Media API - 2 votes https://janezurevc.name/call-help-media-source-plugin-porting
+	* Updating tests in core - 4 votes (this option was chosen to start with) (https://www.drupal.org/node/2735005)
+	* Other - 1 vote
+ 
+## Collaboration & Communication
+* How will the teams work together? Priority is to use standard community tools & practices (e.g. drupal.org), but what will we use to supplement? 
+* We will get started with Google Docs and as soon as possible (with help) try to move things over to d.o issue queue.
+* Ideas: 
+	* Group on d.o? What are the capacities of that for meeting notes and resources?
+	* Actual issue work happens in the d.o. issue queues.
+	* Documentation about the project itself (thinking of the theme in particular) and how it works should go on d.o.
+	* Should we use Rocketship? https://www.drupal.org/project/rocketship tool, helps to organize issues into lanes in a way that’s easy to visualize and helpful for PMs. We could keep notes and additional process documentation there. Might need a Github repo.
+	* Having a wiki page or something in the DDI github and/or on the website about this project and info on when we meet, who to talk to, how to get started would be good. An internal issue repo would be useful (for instance, to make an issue to create that page, etc) -- drnikki offered us this
+	Issue-based discussions about the project (goals, technical decisions) in d.o. Process discussions can live outside of there, though.
+
+## Supporting the Mentoring Program
+* When will we meet on an ongoing basis to support the mentoring program as a whole? 
+* Let’s do one or more group-wide "onboarding" meetings (screenshare/live video) in the near future so that everyone can learn how to contribute to drupal and get set up.
+* Teams meet weekly, the whole crew meets monthly. For the monthly meeting let’s do “we meet on the first Wednesday of the month” or something like that.
+* Async discussion through Slack may be more useful once work has started.  
+* mdrummond offered to provide support for process things like how to get a contrib theme set up, working with issue queues, etc.
+
+## Metrics
+* How will we measure diversity of the cohort(s)? Since one of our goals is to put together diverse teams, what are our measures of success?
+* Self-identification will be incomplete if the results are public and tied to individuals. A private survey would be helpful.
+* The dries contributor report measured contribution in a narrow way. Perhaps a measure of success for the team would be to model what would be better. * By gathering more intersectional data, and being sure to include non-code/non-engineer contributors. Our success, then, might be showing more nuanced numbers, and hope they show more diversity than that first report.
+* Data collection is an ongoing process rather than a one-and-done decision.
+* What is the role of white people, and specifically white men?
+	* The group generally feels okay about white men participating if they can be conscientious about focusing on lending support and helping others to be leaders. White male allies also have network connections and other resources that people in underrepresented groups don’t have access to.
+	* Tara will create affinity groups (women-only, POC-only, etc) and her DMs are open to requests for that. 
+	* Designate a lead for the group as a point person (or 2) for bringing up related issues.
+
+## Measuring Success of the Cohort(s)
+* How will we measure the overall success of the cohort(s)? 
+* Ideas:
+	* A survey to the participants at the end of each session. Ask people how they think it went, what they learned, if they want to keep participating. We can also ask for numbers.
+	* I’d love to get a completed theme up, but that’s a bit of a sprint. It would depend on people’s bandwidths but I think it’s possible, given that we have a reasonably large team.
+	* Measure the number of people involved in this initiative that go on to mentor others (ongoing surveys of “alumni”)
+
+## Working with external groups 
+* How do we want to work with other groups, like Drupal Dojo? 
+* This effort is about specifically supporting people from diverse backgrounds and creating a safer environment for that. If that’s not explicitly at the heart of an effort, I am less confident it will be a safe environment where people feel comfortable contributing.
+* This should be a DDI initiative right now. 
+* It would be great to get this initiative really rolling before we involve any other groups
+
+IF YOU MISSED THE MEETING: You are not left behind! You can still join a team! Let us know what you are interested in!

--- a/teams/backend/contribution/example.md
+++ b/teams/backend/contribution/example.md
@@ -4,7 +4,7 @@ If you just made an account, you’ll need to get a “confirmed” user role be
 
 [Drupal User Role Guide](https://www.drupal.org/node/1887616)
 
-Someone with the community user role can give other people confirmed user roles.
+Someone with the community user role can give other people confirmed user roles. In our case, you can ping @alannaburke or @alexdmccabe in #ddi-contrib-team to have them review your account. 
 
 Note: this guide assumes that you have a Drupal development environment set up already. [You can find another guide for that elsewhere in our documentation](/teams/README.md).
 


### PR DESCRIPTION
Fixes # (probably should have made an issue to track this)

Changes proposed in this pull request: Moving the meeting notes from our first meeting off of google drive and into github. 










